### PR TITLE
Port Sylius 2 and Symfony 7.4 with PHP 8.2 enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /node_modules/
 /composer.lock
 
+/.idea/
+
 /etc/build/*
 !/etc/build/.gitignore
 

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,21 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.1",
-        "sherlockode/advanced-content-bundle": "^0.9.8",
-        "sylius/sylius": "^1.10"
+        "php": "^8.2",
+        "sherlockode/advanced-content-bundle": "^0.10",
+        "sylius/sylius": "^2.0",
+        "symfony/framework-bundle": "^7.4",
+        "symfony/form": "^7.4",
+        "symfony/twig-bundle": "^7.4",
+        "twig/twig": "^3.0"
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-sylius-2": "1.0.x-dev"
+        }
     },
     "autoload": {
         "psr-4": {

--- a/src/Command/ScopeInitCommand.php
+++ b/src/Command/ScopeInitCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Command;
 
 use Sherlockode\AdvancedContentBundle\Manager\ConfigurationManager;
@@ -12,40 +14,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ScopeInitCommand extends Command
 {
-    /**
-     * @var ConfigurationManager
-     */
-    private $configurationManager;
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @var ScopeInitializer
-     */
-    private $scopeInitializer;
-
-    /**
-     * @param ConfigurationManager $configurationManager
-     * @param TranslatorInterface  $translator
-     * @param ScopeInitializer     $scopeInitializer
-     * @param                      $name
-     */
     public function __construct(
-        ConfigurationManager $configurationManager,
-        TranslatorInterface $translator,
-        ScopeInitializer $scopeInitializer,
-        $name = null
+        private readonly ConfigurationManager $configurationManager,
+        private readonly TranslatorInterface $translator,
+        private readonly ScopeInitializer $scopeInitializer,
     ) {
-        parent::__construct($name);
-        $this->configurationManager = $configurationManager;
-        $this->translator = $translator;
-        $this->scopeInitializer = $scopeInitializer;
+        parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('sherlockode:sylius-acb:init-scope')
@@ -53,46 +30,31 @@ class ScopeInitCommand extends Command
         ;
     }
 
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return int|void
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 
         if (!$this->configurationManager->isScopesEnabled()) {
             $io->info($this->translator->trans('sherlockode_sylius_acb.scopes.disabled'));
 
-            if (defined(sprintf('%s::SUCCESS', get_class($this)))) {
-                return self::SUCCESS;
-            }
-            return;
+            return self::SUCCESS;
         }
+
         if (!$this->scopeInitializer->hasMissingScopes()) {
             $io->info($this->translator->trans('sherlockode_sylius_acb.scopes.up_to_date'));
 
-            if (defined(sprintf('%s::SUCCESS', get_class($this)))) {
-                return self::SUCCESS;
-            }
-            return;
+            return self::SUCCESS;
         }
 
         try {
             $this->scopeInitializer->init();
             $io->success($this->translator->trans('sherlockode_sylius_acb.scopes.init_success'));
-            if (defined(sprintf('%s::SUCCESS', get_class($this)))) {
-                return self::SUCCESS;
-            }
-            return;
+
+            return self::SUCCESS;
         } catch (\Exception $e) {
             $io->error($e->getMessage());
 
-            if (defined(sprintf('%s::FAILURE', get_class($this)))) {
-                return self::FAILURE;
-            }
+            return self::FAILURE;
         }
     }
 }

--- a/src/Controller/PreviewController.php
+++ b/src/Controller/PreviewController.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Controller;
 
 use Sherlockode\AdvancedContentBundle\Scope\ScopeHandlerInterface;
 use Sherlockode\SyliusAdvancedContentPlugin\Preview\ViewHandlerInterface;
 use Sherlockode\SyliusAdvancedContentPlugin\Scope\ChannelLocaleScopeHandler;
-use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,48 +15,15 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class PreviewController extends AbstractController
 {
-    /**
-     * @var ChannelLocaleScopeHandler
-     */
-    private $channelLocaleScopeHandler;
-
-    /**
-     * @var RepositoryInterface
-     */
-    private $pageRepository;
-
-    /**
-     * @var ViewHandlerInterface
-     */
-    private $viewHandler;
-
-    /**
-     * @param ScopeHandlerInterface $channelLocaleScopeHandler
-     * @param RepositoryInterface   $pageRepository
-     * @param ViewHandlerInterface  $viewHandler
-     */
     public function __construct(
-        ScopeHandlerInterface $channelLocaleScopeHandler,
-        RepositoryInterface $pageRepository,
-        ViewHandlerInterface $viewHandler
+        private readonly ScopeHandlerInterface $channelLocaleScopeHandler,
+        private readonly RepositoryInterface $pageRepository,
+        private readonly ViewHandlerInterface $viewHandler,
     ) {
-        $this->channelLocaleScopeHandler = $channelLocaleScopeHandler;
-        $this->pageRepository = $pageRepository;
-        $this->viewHandler = $viewHandler;
     }
 
-    /**
-     * @param Request $request
-     * @param string  $pageIdentifier
-     *
-     * @return Response
-     *
-     * @throws \Exception
-     */
-    public function previewAction(
-        Request $request,
-        string $pageIdentifier
-    ): Response {
+    public function previewAction(Request $request, string $pageIdentifier): Response
+    {
         $channelCode = $request->query->get('_channel_code');
         $localeCode = $request->query->get('_locale');
 
@@ -67,7 +36,7 @@ class PreviewController extends AbstractController
             throw new NotFoundHttpException(sprintf(
                 'Scope for channel "%s" and locale "%s" does not exists',
                 $channelCode,
-                $localeCode
+                $localeCode,
             ));
         }
 
@@ -77,7 +46,7 @@ class PreviewController extends AbstractController
             throw new NotFoundHttpException(sprintf(
                 'Page with scope for channel "%s" and locale "%s" does not exists',
                 $channelCode,
-                $localeCode
+                $localeCode,
             ));
         }
 
@@ -86,7 +55,7 @@ class PreviewController extends AbstractController
         if (!$template) {
             throw new \Exception(sprintf(
                 'Cannot find any template for the page "%s" preview',
-                $page->getPageIdentifier()
+                $page->getPageIdentifier(),
             ));
         }
 

--- a/src/Controller/ScopeController.php
+++ b/src/Controller/ScopeController.php
@@ -1,50 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Controller;
 
 use Sherlockode\AdvancedContentBundle\Manager\ConfigurationManager;
 use Sherlockode\SyliusAdvancedContentPlugin\Scope\ScopeInitializer;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ScopeController extends AbstractController
 {
-    /**
-     * @var ConfigurationManager
-     */
-    private $configurationManager;
-
-    /**
-     * @var ScopeInitializer
-     */
-    private $scopeInitializer;
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @param ConfigurationManager $configurationManager
-     * @param ScopeInitializer     $scopeInitializer
-     * @param TranslatorInterface  $translator
-     */
     public function __construct(
-        ConfigurationManager $configurationManager,
-        ScopeInitializer $scopeInitializer,
-        TranslatorInterface $translator
+        private readonly ConfigurationManager $configurationManager,
+        private readonly ScopeInitializer $scopeInitializer,
+        private readonly TranslatorInterface $translator,
     ) {
-        $this->configurationManager = $configurationManager;
-        $this->scopeInitializer = $scopeInitializer;
-        $this->translator = $translator;
     }
 
-    /**
-     * @return Response
-     */
-    public function updateScopesAction()
+    public function updateScopesAction(): Response
     {
         if (!$this->configurationManager->isScopesEnabled()) {
             $this->addFlash('error', $this->translator->trans('sherlockode_sylius_acb.scopes.disabled'));

--- a/src/DependencyInjection/Compiler/SyliusClassMappingCompilerPass.php
+++ b/src/DependencyInjection/Compiler/SyliusClassMappingCompilerPass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/src/DependencyInjection/SherlockodeSyliusAdvancedContentExtension.php
+++ b/src/DependencyInjection/SherlockodeSyliusAdvancedContentExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
 use Doctrine\Common\Collections\Collection;

--- a/src/Entity/ContentInterface.php
+++ b/src/Entity/ContentInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
-use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Resource\Model\ResourceInterface;
 
 interface ContentInterface extends ResourceInterface
 {

--- a/src/Entity/ContentVersion.php
+++ b/src/Entity/ContentVersion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
 use Sherlockode\AdvancedContentBundle\Model\ContentVersion as BaseContentVersion;

--- a/src/Entity/ContentVersionInterface.php
+++ b/src/Entity/ContentVersionInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
-use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Resource\Model\ResourceInterface;
 
 interface ContentVersionInterface extends ResourceInterface
 {

--- a/src/Entity/Page.php
+++ b/src/Entity/Page.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
 use Doctrine\Common\Collections\Collection;
@@ -8,7 +10,7 @@ use Gedmo\Blameable\Traits\BlameableEntity;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Sherlockode\AdvancedContentBundle\Model\Page as BasePage;
 use Sherlockode\AdvancedContentBundle\Model\PageVersionInterface;
-use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Resource\Model\ResourceInterface;
 
 class Page extends BasePage implements PageInterface
 {

--- a/src/Entity/PageInterface.php
+++ b/src/Entity/PageInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
-use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Resource\Model\ResourceInterface;
 
 interface PageInterface extends ResourceInterface
 {

--- a/src/Entity/PageMeta.php
+++ b/src/Entity/PageMeta.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
 use Doctrine\Common\Collections\Collection;

--- a/src/Entity/PageMetaInterface.php
+++ b/src/Entity/PageMetaInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
-use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Resource\Model\ResourceInterface;
 
 interface PageMetaInterface extends ResourceInterface
 {

--- a/src/Entity/PageMetaVersion.php
+++ b/src/Entity/PageMetaVersion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
 use Sherlockode\AdvancedContentBundle\Model\PageMetaVersion as BasePageMetaVersion;

--- a/src/Entity/PageMetaVersionInterface.php
+++ b/src/Entity/PageMetaVersionInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
-use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Resource\Model\ResourceInterface;
 
 interface PageMetaVersionInterface extends ResourceInterface
 {

--- a/src/Entity/PageType.php
+++ b/src/Entity/PageType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Entity/PageTypeInterface.php
+++ b/src/Entity/PageTypeInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
-use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Resource\Model\ResourceInterface;
 
 interface PageTypeInterface extends ResourceInterface
 {

--- a/src/Entity/PageVersion.php
+++ b/src/Entity/PageVersion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
 use Sherlockode\AdvancedContentBundle\Model\PageVersion as BasePageVersion;

--- a/src/Entity/PageVersionInterface.php
+++ b/src/Entity/PageVersionInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
-use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Resource\Model\ResourceInterface;
 
 interface PageVersionInterface extends ResourceInterface
 {

--- a/src/Entity/Scope.php
+++ b/src/Entity/Scope.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
 use App\Entity\Channel\Channel;

--- a/src/Entity/ScopeInterface.php
+++ b/src/Entity/ScopeInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sherlockode\SyliusAdvancedContentPlugin\Entity;
 
-use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Resource\Model\ResourceInterface;
 
 interface ScopeInterface extends ResourceInterface
 {

--- a/src/EventListener/AdminGridListener.php
+++ b/src/EventListener/AdminGridListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\EventListener;
 
 use Sherlockode\AdvancedContentBundle\Manager\ConfigurationManager;
@@ -10,52 +12,20 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AdminGridListener
 {
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @var ScopeInitializer
-     */
-    private $scopeInitializer;
-
-    /**
-     * @var ConfigurationManager
-     */
-    private $configurationManager;
-
-    /**
-     * @param RequestStack         $requestStack
-     * @param TranslatorInterface  $translator
-     * @param ScopeInitializer     $scopeInitializer
-     * @param ConfigurationManager $configurationManager
-     */
     public function __construct(
-        RequestStack $requestStack,
-        TranslatorInterface $translator,
-        ScopeInitializer $scopeInitializer,
-        ConfigurationManager $configurationManager
+        private readonly RequestStack $requestStack,
+        private readonly TranslatorInterface $translator,
+        private readonly ScopeInitializer $scopeInitializer,
+        private readonly ConfigurationManager $configurationManager,
     ) {
-        $this->requestStack = $requestStack;
-        $this->translator = $translator;
-        $this->scopeInitializer = $scopeInitializer;
-        $this->configurationManager = $configurationManager;
     }
 
-    /**
-     * @param GenericEvent $event
-     */
     public function checkScopeInitialization(GenericEvent $event): void
     {
         if (!$this->configurationManager->isScopesEnabled()) {
             return;
         }
+
         if (!$this->scopeInitializer->hasMissingScopes()) {
             return;
         }

--- a/src/EventListener/AdminVersionListener.php
+++ b/src/EventListener/AdminVersionListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
@@ -10,42 +12,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AdminVersionListener
 {
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @var ConfigurationManager
-     */
-    private $configurationManager;
-
-    /**
-     * @var EntityManagerInterface
-     */
-    private $em;
-
-    /**
-     * @param RequestStack           $requestStack
-     * @param TranslatorInterface    $translator
-     * @param ConfigurationManager   $configurationManager
-     * @param EntityManagerInterface $em
-     */
     public function __construct(
-        RequestStack $requestStack,
-        TranslatorInterface $translator,
-        ConfigurationManager $configurationManager,
-        EntityManagerInterface $em
+        private readonly RequestStack $requestStack,
+        private readonly TranslatorInterface $translator,
+        private readonly ConfigurationManager $configurationManager,
+        private readonly EntityManagerInterface $em,
     ) {
-        $this->requestStack = $requestStack;
-        $this->translator = $translator;
-        $this->configurationManager = $configurationManager;
-        $this->em = $em;
     }
 
     public function editContentVersionMessage(): void
@@ -58,9 +30,6 @@ class AdminVersionListener
         $this->addVersionMessage('page_version');
     }
 
-    /**
-     * @param string $entityClass
-     */
     private function addVersionMessage(string $entityClass): void
     {
         $request = $this->requestStack->getMainRequest();
@@ -73,7 +42,7 @@ class AdminVersionListener
             return;
         }
 
-        /** @var VersionInterface $version */
+        /** @var VersionInterface|null $version */
         $version = $this->em->getRepository($this->configurationManager->getEntityClass($entityClass))->find($versionId);
         if ($version === null) {
             return;
@@ -82,7 +51,7 @@ class AdminVersionListener
         $formatter = \IntlDateFormatter::create(
             $request->getLocale(),
             \IntlDateFormatter::MEDIUM,
-            \IntlDateFormatter::MEDIUM
+            \IntlDateFormatter::MEDIUM,
         );
 
         $this->requestStack->getSession()->getFlashBag()

--- a/src/EventListener/ChannelListener.php
+++ b/src/EventListener/ChannelListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\EventListener;
 
 use Doctrine\ORM\Event\OnFlushEventArgs;

--- a/src/Factory/NewContentFactory.php
+++ b/src/Factory/NewContentFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Factory;
 
 use Doctrine\ORM\EntityManagerInterface;
@@ -8,8 +10,8 @@ use Sherlockode\AdvancedContentBundle\Manager\ContentManager;
 use Sherlockode\AdvancedContentBundle\Model\ContentInterface;
 use Sylius\Bundle\ResourceBundle\Controller\NewResourceFactoryInterface;
 use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
-use Sylius\Component\Resource\Factory\FactoryInterface;
-use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Resource\Factory\FactoryInterface;
+use Sylius\Resource\Model\ResourceInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class NewContentFactory implements NewResourceFactoryInterface

--- a/src/Factory/NewPageFactory.php
+++ b/src/Factory/NewPageFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Factory;
 
 use Doctrine\ORM\EntityManagerInterface;
@@ -8,8 +10,8 @@ use Sherlockode\AdvancedContentBundle\Manager\PageManager;
 use Sherlockode\AdvancedContentBundle\Model\PageInterface;
 use Sylius\Bundle\ResourceBundle\Controller\NewResourceFactoryInterface;
 use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
-use Sylius\Component\Resource\Factory\FactoryInterface;
-use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Resource\Factory\FactoryInterface;
+use Sylius\Resource\Model\ResourceInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class NewPageFactory implements NewResourceFactoryInterface

--- a/src/Grid/Filter/PageStatusFilter.php
+++ b/src/Grid/Filter/PageStatusFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Grid\Filter;
 
 use Sylius\Component\Grid\Data\DataSourceInterface;

--- a/src/Grid/Filter/PageTitleFilter.php
+++ b/src/Grid/Filter/PageTitleFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Grid\Filter;
 
 use Sylius\Component\Grid\Data\DataSourceInterface;

--- a/src/Grid/Form/PageStatusType.php
+++ b/src/Grid/Form/PageStatusType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Grid\Form;
 
 use Sherlockode\AdvancedContentBundle\Model\PageInterface;

--- a/src/Grid/Form/PageTitleType.php
+++ b/src/Grid/Form/PageTitleType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Grid\Form;
 
 use Sylius\Component\Grid\Filter\StringFilter;

--- a/src/Menu/AdminMenuListener.php
+++ b/src/Menu/AdminMenuListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Menu;
 
 use Sylius\Bundle\UiBundle\Menu\Event\MenuBuilderEvent;

--- a/src/Preview/ViewHandler.php
+++ b/src/Preview/ViewHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Preview;
 
 use Sherlockode\AdvancedContentBundle\Model\PageInterface;

--- a/src/Preview/ViewHandlerInterface.php
+++ b/src/Preview/ViewHandlerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Preview;
 
 use Sherlockode\AdvancedContentBundle\Model\PageInterface;

--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Repository;
 
 use Doctrine\ORM\NonUniqueResultException;
@@ -52,10 +54,8 @@ class ContentRepository extends EntityRepository
             $qb->join('content.scopes', 'scope')
                 ->andWhere('scope.channel = :channel')
                 ->andWhere('scope.locale = :locale')
-                ->setParameters([
-                    'channel' => $scope->getChannel(),
-                    'locale'  => $scope->getLocale(),
-                ]);
+                ->setParameter('channel', $scope->getChannel())
+                ->setParameter('locale', $scope->getLocale());
         }
 
         return $qb;

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Repository;
 
 use App\Entity\Channel\Channel;
@@ -9,7 +11,7 @@ use Doctrine\ORM\QueryBuilder;
 use Sherlockode\AdvancedContentBundle\Model\PageInterface;
 use Sherlockode\AdvancedContentBundle\Model\ScopeInterface;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
-use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 
 class PageRepository extends EntityRepository
 {
@@ -63,10 +65,8 @@ class PageRepository extends EntityRepository
             $qb->join('page.scopes', 'scope')
                 ->andWhere('scope.channel = :channel')
                 ->andWhere('scope.locale = :locale')
-                ->setParameters([
-                    'channel' => $scope->getChannel(),
-                    'locale'  => $scope->getLocale(),
-                ]);
+                ->setParameter('channel', $scope->getChannel())
+                ->setParameter('locale', $scope->getLocale());
         }
 
         return $qb;

--- a/src/Resources/config/admin_routing.yaml
+++ b/src/Resources/config/admin_routing.yaml
@@ -2,10 +2,12 @@ sherlockode_sylius_acb_admin_page:
     resource: |
         alias: sherlockode_sylius_acb.page
         section: admin
-        templates: '@SyliusAdmin\\Crud'
+        templates: "@SyliusAdmin\\shared\\crud"
         except: ['show']
         redirect: update
         grid: sherlockode_sylius_acb_admin_page
+        form:
+            type: Sherlockode\AdvancedContentBundle\Form\Type\PageType
         vars:
             index:
                 icon: 'sticky note'
@@ -18,10 +20,12 @@ sherlockode_sylius_acb_admin_content:
     resource: |
         alias: sherlockode_sylius_acb.content
         section: admin
-        templates: '@SyliusAdmin\\Crud'
+        templates: "@SyliusAdmin\\shared\\crud"
         except: ['show']
         redirect: update
         grid: sherlockode_sylius_acb_admin_content
+        form:
+            type: Sherlockode\AdvancedContentBundle\Form\Type\ContentType
         vars:
             index:
                 icon: 'sticky note outline'

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="sherlockode_sylius_acb.scope_init_command"
+                 class="Sherlockode\SyliusAdvancedContentPlugin\Command\ScopeInitCommand">
+            <argument type="service" id="sherlockode_advanced_content.configuration_manager"/>
+            <argument type="service" id="translator"/>
+            <argument type="service" id="sherlockode_sylius_acb.scope_initializer"/>
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -2,4 +2,5 @@ imports:
     - { resource: "sylius_grid.yaml" }
     - { resource: "sylius_resource.yaml" }
     - { resource: "services.yaml" }
+    - { resource: "commands.xml" }
     - { resource: "events.yaml" }

--- a/src/Resources/config/doctrine/Page.orm.xml
+++ b/src/Resources/config/doctrine/Page.orm.xml
@@ -13,6 +13,19 @@
             <generator strategy="AUTO" />
         </id>
 
+        <field name="createdAt" column="created_at" type="datetime">
+            <gedmo:timestampable on="create"/>
+        </field>
+        <field name="updatedAt" column="updated_at" type="datetime">
+            <gedmo:timestampable on="update"/>
+        </field>
+        <field name="createdBy" column="created_by" type="string" length="255" nullable="true">
+            <gedmo:blameable on="create"/>
+        </field>
+        <field name="updatedBy" column="updated_by" type="string" length="255" nullable="true">
+            <gedmo:blameable on="update"/>
+        </field>
+
         <one-to-one field="content" target-entity="Sherlockode\SyliusAdvancedContentPlugin\Entity\ContentInterface" mapped-by="page">
             <cascade>
                 <cascade-persist />

--- a/src/Resources/config/events.yaml
+++ b/src/Resources/config/events.yaml
@@ -1,22 +1,3 @@
-sylius_ui:
-    events:
-        sherlockode_sylius_acb.admin.content.create.stylesheets:
-            blocks:
-                sylius_acb:
-                    template: "@SherlockodeSyliusAdvancedContentPlugin/admin/stylesheets.html.twig"
-        sherlockode_sylius_acb.admin.content.update.stylesheets:
-            blocks:
-                sylius_acb:
-                    template: "@SherlockodeSyliusAdvancedContentPlugin/admin/stylesheets.html.twig"
-        sherlockode_sylius_acb.admin.page.create.stylesheets:
-            blocks:
-                sylius_acb:
-                    template: "@SherlockodeSyliusAdvancedContentPlugin/admin/stylesheets.html.twig"
-        sherlockode_sylius_acb.admin.page.update.stylesheets:
-            blocks:
-                sylius_acb:
-                    template: "@SherlockodeSyliusAdvancedContentPlugin/admin/stylesheets.html.twig"
-
 services:
     sherlockode_sylius_acb.listener.grid:
         class: Sherlockode\SyliusAdvancedContentPlugin\EventListener\AdminGridListener

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -22,14 +22,6 @@ services:
         arguments:
             - '@doctrine.orm.entity_manager'
             - '@sherlockode_advanced_content.configuration_manager'
-    sherlockode_sylius_acb.scope_init_command:
-        class: Sherlockode\SyliusAdvancedContentPlugin\Command\ScopeInitCommand
-        arguments:
-            - '@sherlockode_advanced_content.configuration_manager'
-            - '@translator'
-            - '@sherlockode_sylius_acb.scope_initializer'
-        tags:
-            - { name: console.command }
     sherlockode_sylius_acb.controller.preview:
         class: Sherlockode\SyliusAdvancedContentPlugin\Controller\PreviewController
         public: true

--- a/src/Resources/config/sylius_resource.yaml
+++ b/src/Resources/config/sylius_resource.yaml
@@ -1,45 +1,36 @@
 sylius_resource:
     resources:
         sherlockode_sylius_acb.content:
-            driver: doctrine/orm
             classes:
                 model: Sherlockode\SyliusAdvancedContentPlugin\Entity\Content
                 interface: Sherlockode\SyliusAdvancedContentPlugin\Entity\ContentInterface
-                form: Sherlockode\AdvancedContentBundle\Form\Type\ContentType
+                repository: Sherlockode\SyliusAdvancedContentPlugin\Repository\ContentRepository
         sherlockode_sylius_acb.content_version:
-            driver: doctrine/orm
             classes:
                 model: Sherlockode\SyliusAdvancedContentPlugin\Entity\ContentVersion
                 interface: Sherlockode\SyliusAdvancedContentPlugin\Entity\ContentVersionInterface
         sherlockode_sylius_acb.page:
-            driver: doctrine/orm
             classes:
                 model: Sherlockode\SyliusAdvancedContentPlugin\Entity\Page
-                form: Sherlockode\AdvancedContentBundle\Form\Type\PageType
                 interface: Sherlockode\SyliusAdvancedContentPlugin\Entity\PageInterface
                 repository: Sherlockode\SyliusAdvancedContentPlugin\Repository\PageRepository
         sherlockode_sylius_acb.page_meta:
-            driver: doctrine/orm
             classes:
                 model: Sherlockode\SyliusAdvancedContentPlugin\Entity\PageMeta
                 interface: Sherlockode\SyliusAdvancedContentPlugin\Entity\PageMetaInterface
         sherlockode_sylius_acb.page_meta_version:
-            driver: doctrine/orm
             classes:
                 model: Sherlockode\SyliusAdvancedContentPlugin\Entity\PageMetaVersion
                 interface: Sherlockode\SyliusAdvancedContentPlugin\Entity\PageMetaVersionInterface
         sherlockode_sylius_acb.page_type:
-            driver: doctrine/orm
             classes:
                 model: Sherlockode\SyliusAdvancedContentPlugin\Entity\PageType
                 interface: Sherlockode\SyliusAdvancedContentPlugin\Entity\PageTypeInterface
         sherlockode_sylius_acb.page_version:
-            driver: doctrine/orm
             classes:
                 model: Sherlockode\SyliusAdvancedContentPlugin\Entity\PageVersion
                 interface: Sherlockode\SyliusAdvancedContentPlugin\Entity\PageVersionInterface
         sherlockode_sylius_acb.scope:
-            driver: doctrine/orm
             classes:
                 model: Sherlockode\SyliusAdvancedContentPlugin\Entity\Scope
                 interface: Sherlockode\SyliusAdvancedContentPlugin\Entity\ScopeInterface

--- a/src/Resources/js/AdvancedContentBundle/acb-notification.js
+++ b/src/Resources/js/AdvancedContentBundle/acb-notification.js
@@ -1,20 +1,38 @@
-import $ from 'jquery';
-import 'semantic-ui-css/components/modal';
+import Modal from 'bootstrap/js/dist/modal';
 
 let notifAlert = function (message) {
-  alert(message);
+  window.alert(message);
 };
 
 let notifConfirm = function (message, callback) {
-  $('#confirmation-modal').find('.content p').html(message);
-    $('#confirmation-button')
-      .off('click')
-      .on('click', (event) => {
-        callback();
-      })
-    ;
+  const modalElement = document.getElementById('confirmation-modal');
 
-  $('#confirmation-modal').modal('show');
+  if (modalElement === null) {
+    if (window.confirm(message)) {
+      callback();
+    }
+
+    return;
+  }
+
+  const body = modalElement.querySelector('.modal-body');
+  if (body !== null) {
+    body.innerHTML = message;
+  }
+
+  const modal = Modal.getOrCreateInstance(modalElement);
+  const confirmButton = modalElement.querySelector('#confirmation-button');
+
+  if (confirmButton !== null) {
+    const freshButton = confirmButton.cloneNode(true);
+    confirmButton.replaceWith(freshButton);
+    freshButton.addEventListener('click', () => {
+      modal.hide();
+      callback();
+    }, { once: true });
+  }
+
+  modal.show();
 };
 
 export {notifAlert, notifConfirm};

--- a/src/Resources/views/AdvancedContentBundle/Common/Macros/classes.html.twig
+++ b/src/Resources/views/AdvancedContentBundle/Common/Macros/classes.html.twig
@@ -1,16 +1,16 @@
 {%- macro table() -%}
-    ui celled table
+    table table-bordered
 {%- endmacro -%}
 
 {%- macro button() -%}
-    ui button
+    btn btn-secondary
 {%- endmacro -%}
 {%- macro buttonPrimary() -%}
-    ui button primary
+    btn btn-primary
 {%- endmacro -%}
 {%- macro buttonSuccess() -%}
-    ui button primary
+    btn btn-success
 {%- endmacro -%}
 {%- macro buttonIcon() -%}
-    ui button icon basic
+    btn btn-icon
 {%- endmacro -%}

--- a/src/Resources/views/AdvancedContentBundle/Common/Macros/collapse.html.twig
+++ b/src/Resources/views/AdvancedContentBundle/Common/Macros/collapse.html.twig
@@ -1,6 +1,6 @@
 {% macro buildAccordion(data) %}
     {% for item in data %}
-        <div class="field">
+        <div class="mb-3">
             <details>
                 <summary>{{ item.title|raw }}</summary>
                 {{ item.content|raw }}

--- a/src/Resources/views/AdvancedContentBundle/Common/Macros/tabs.html.twig
+++ b/src/Resources/views/AdvancedContentBundle/Common/Macros/tabs.html.twig
@@ -1,31 +1,35 @@
 {% macro buildTabs(tabsData, extraClass) %}
-    <div class="ui top attached tabular menu {{ extraClass }}">
+    <ul class="nav nav-tabs {{ extraClass }}" role="tablist">
         {% for tabData in tabsData %}
-            <button type="button"
-                    class="item {% if tabData.active %}active{% endif %}"
-                    id="{{ tabData.id }}-tab"
-                    data-tab="{{ tabData.id }}"
+            <li class="nav-item" role="presentation">
+                <button type="button"
+                        class="nav-link {% if tabData.active %}active{% endif %}"
+                        id="{{ tabData.id }}-tab"
+                        data-bs-toggle="tab"
+                        data-bs-target="#{{ tabData.id }}"
+                        role="tab"
+                        aria-controls="{{ tabData.id }}"
+                        aria-selected="{{ tabData.active ? 'true' : 'false' }}"
+                >
+                    {{ tabData.label }}
+                </button>
+            </li>
+        {% endfor %}
+    </ul>
+    <div class="tab-content pt-3">
+        {% for tabData in tabsData %}
+            <div class="tab-pane fade {% if tabData.active %}show active{% endif %}"
+                 id="{{ tabData.id }}"
+                 role="tabpanel"
+                 aria-labelledby="{{ tabData.id }}-tab"
             >
-                {{ tabData.label }}
-            </button>
+                {{ tabData.content }}
+            </div>
         {% endfor %}
     </div>
-    {% for tabData in tabsData %}
-        <div class="ui bottom attached tab segment {% if tabData.active %}active{% endif %}"
-             data-tab="{{ tabData.id }}"
-             role="tabpanel"
-             aria-labelledby="{{ tabData.id }}-tab"
-        >
-            {{ tabData.content }}
-        </div>
-    {% endfor %}
 {% endmacro %}
 
 {% macro buildEditElementsTabs(tabsData) %}
     {% import _self as tabs %}
     {{ tabs.buildTabs(tabsData, 'acb-tabs') }}
-
-    <script>
-        jQuery('.menu.acb-tabs .item').tab();
-    </script>
 {% endmacro %}

--- a/src/Resources/views/AdvancedContentBundle/Form/base_theme.html.twig
+++ b/src/Resources/views/AdvancedContentBundle/Form/base_theme.html.twig
@@ -1,1 +1,1 @@
-{% extends '@SyliusUi/Form/theme.html.twig' %}
+{% extends '@SyliusAdmin/shared/form_theme.html.twig' %}

--- a/src/Resources/views/Grid/Action/duplicate.html.twig
+++ b/src/Resources/views/Grid/Action/duplicate.html.twig
@@ -1,5 +1,6 @@
-{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
+{% set url = options.link.url|default(path(options.link.route, options.link.parameters|default({}))) %}
 
-{% set path = options.link.url|default(path(options.link.route, options.link.parameters|default({}))) %}
-
-{{ buttons.default(path, action.label, null, action.icon, 'blue') }}
+<a href="{{ url }}" class="btn btn-sm btn-outline-secondary">
+    <i class="{{ action.icon }}"></i>
+    {{ action.label|trans }}
+</a>

--- a/src/Resources/views/Page/Grid/Fields/status.html.twig
+++ b/src/Resources/views/Page/Grid/Fields/status.html.twig
@@ -1,16 +1,16 @@
 {% set status = data %}
 {% if status == constant('Sherlockode\\AdvancedContentBundle\\Model\\PageInterface::STATUS_PUBLISHED') %}
-    <span class="ui teal label">
-        <i class="checkmark icon"></i>
+    <span class="badge bg-green-lt">
+        <i class="fas fa-check"></i>
         {{ 'page.form.statuses.published'|trans({}, 'AdvancedContentBundle') }}
     </span>
 {% elseif status == constant('Sherlockode\\AdvancedContentBundle\\Model\\PageInterface::STATUS_TRASH') %}
-    <span class="ui red label">
-        <i class="remove icon"></i>
+    <span class="badge bg-red-lt">
+        <i class="fas fa-times"></i>
         {{ 'page.form.statuses.trash'|trans({}, 'AdvancedContentBundle') }}
     </span>
 {% else %}
-    <span class="ui grey label">
+    <span class="badge bg-secondary-lt">
         {{ 'page.form.statuses.draft'|trans({}, 'AdvancedContentBundle') }}
     </span>
 {% endif %}

--- a/src/Resources/views/Page/Grid/Filters/pageStatus.html.twig
+++ b/src/Resources/views/Page/Grid/Filters/pageStatus.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
+{% form_theme form '@SyliusAdmin/shared/form_theme.html.twig' %}
 
 <div class="sylius-filters__group">
     {{ form_row(form) }}

--- a/src/Resources/views/Page/Grid/Filters/pageTitle.html.twig
+++ b/src/Resources/views/Page/Grid/Filters/pageTitle.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
+{% form_theme form '@SyliusAdmin/shared/form_theme.html.twig' %}
 
 <div class="sylius-filters__group">
     {{ form_row(form.type) }}

--- a/src/Resources/views/admin/Content/_form.html.twig
+++ b/src/Resources/views/admin/Content/_form.html.twig
@@ -1,73 +1,96 @@
+{% if form is not defined %}
+    {% set form = hookable_metadata.context.form|default(null) %}
+{% endif %}
+{% if resource is not defined %}
+    {% set resource = hookable_metadata.context.resource|default(null) %}
+{% endif %}
 {% form_theme form with [
-    '@SyliusAdmin/Form/theme.html.twig',
+    '@SyliusAdmin/shared/form_theme.html.twig',
     '@SherlockodeAdvancedContent/Form/content.html.twig'
 ] %}
 
 {% set content = form.vars.data %}
 {{ form_errors(form) }}
-<div class="ui grid">
-    <div class="twelve wide column">
-        <div class="ui fluid styled accordion">
-            <div class="active title">
-                <i class="dropdown icon"></i>
-                {{ 'sherlockode_sylius_acb.form.general'|trans }}
-            </div>
-            <div class="active content">
-                {{ form_row(form.name) }}
-                {{ form_row(form.slug) }}
-            </div>
-        </div>
-        <div class="ui hidden divider"></div>
-        <div class="ui fluid styled accordion">
-            <div class="active title">
-                <i class="dropdown icon"></i>
-                {{ 'sherlockode_sylius_acb.form.content'|trans }}
-            </div>
-            <div class="active content">
-                {{ form_row(form.data) }}
-            </div>
-        </div>
-        {% if content.id %}
-            <div class="ui hidden divider"></div>
-            <div class="ui fluid styled accordion">
-                <div class="active title">
-                    <i class="dropdown icon"></i>
-                    {{ 'sherlockode_sylius_acb.form.history'|trans }}
+
+<div class="row">
+    <div class="col-lg-8">
+        <div class="accordion mb-3" id="acb-content-general">
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#acb-content-general-body">
+                        {{ 'sherlockode_sylius_acb.form.general'|trans }}
+                    </button>
+                </h2>
+                <div id="acb-content-general-body" class="accordion-collapse collapse show">
+                    <div class="accordion-body">
+                        {{ form_row(form.name) }}
+                        {{ form_row(form.slug) }}
+                    </div>
                 </div>
-                <div class="active content">
-                    {{ include('@SherlockodeAdvancedContent/Version/content_list.html.twig', {'content': content}) }}
+            </div>
+        </div>
+
+        <div class="accordion mb-3" id="acb-content-data">
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#acb-content-data-body">
+                        {{ 'sherlockode_sylius_acb.form.content'|trans }}
+                    </button>
+                </h2>
+                <div id="acb-content-data-body" class="accordion-collapse collapse show">
+                    <div class="accordion-body">
+                        {{ form_row(form.data) }}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {% if content.id %}
+            <div class="accordion mb-3" id="acb-content-history">
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#acb-content-history-body">
+                            {{ 'sherlockode_sylius_acb.form.history'|trans }}
+                        </button>
+                    </h2>
+                    <div id="acb-content-history-body" class="accordion-collapse collapse">
+                        <div class="accordion-body">
+                            {{ include('@SherlockodeAdvancedContent/Version/content_list.html.twig', {'content': content}) }}
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </div>
-    <div class="four wide column">
+
+    <div class="col-lg-4">
         {% if form.scopes is defined %}
-            <div class="ui fluid styled accordion">
-                <div class="active title">
-                    <i class="dropdown icon"></i>
-                    {{ 'sherlockode_sylius_acb.form.scope'|trans }}
-                </div>
-                <div class="active content">
-                    <div class="field">
-                        {{ form_widget(form.scopes) }}
-                    </div>
-                    <div class="ui checkbox">
-                        <input type="checkbox" id="acb-scopes-select-all">
-                        <label for="acb-scopes-select-all">{{ 'content.form.scopes_select_all'|trans({}, 'AdvancedContentBundle') }}</label>
+            <div class="card mb-3">
+                <div class="card-header">{{ 'sherlockode_sylius_acb.form.scope'|trans }}</div>
+                <div class="card-body">
+                    {{ form_widget(form.scopes) }}
+                    <div class="form-check mt-2">
+                        <input class="form-check-input" type="checkbox" id="acb-scopes-select-all">
+                        <label class="form-check-label" for="acb-scopes-select-all">
+                            {{ 'content.form.scopes_select_all'|trans({}, 'AdvancedContentBundle') }}
+                        </label>
                     </div>
                 </div>
             </div>
         {% endif %}
-        <div class="ui segment center aligned">
-            <div class="ui buttons">
-                <button class="ui labeled icon primary button" type="submit">
+
+        <div class="card">
+            <div class="card-body text-center">
+                <button class="btn btn-primary" type="submit">
                     {% if content.id %}
-                        <i class="save icon"></i> {{ 'sylius.ui.save_changes'|trans }}
+                        <i class="fas fa-save"></i> {{ 'sylius.ui.save_changes'|trans }}
                     {% else %}
-                        <i class="plus icon"></i> {{ 'sylius.ui.create'|trans }}
+                        <i class="fas fa-plus"></i> {{ 'sylius.ui.create'|trans }}
                     {% endif %}
                 </button>
             </div>
         </div>
     </div>
 </div>
+
+{{ include('@SherlockodeSyliusAdvancedContentPlugin/admin/_confirmation_modal.html.twig') }}

--- a/src/Resources/views/admin/Page/_form.html.twig
+++ b/src/Resources/views/admin/Page/_form.html.twig
@@ -1,91 +1,120 @@
+{% if form is not defined %}
+    {% set form = hookable_metadata.context.form|default(null) %}
+{% endif %}
+{% if resource is not defined %}
+    {% set resource = hookable_metadata.context.resource|default(null) %}
+{% endif %}
 {% form_theme form with [
-    '@SyliusAdmin/Form/theme.html.twig',
+    '@SyliusAdmin/shared/form_theme.html.twig',
     '@SherlockodeAdvancedContent/Form/content.html.twig'
 ] %}
 
 {% set page = form.vars.data %}
 {{ form_errors(form) }}
-<div class="ui grid">
-    <div class="twelve wide column">
-        <div class="ui fluid styled accordion">
-            <div class="active title">
-                <i class="dropdown icon"></i>
-                {{ 'page.form.general'|trans({}, 'AdvancedContentBundle') }}
-            </div>
-            <div class="active content">
-                {{ form_row(form.pageIdentifier) }}
-                {{ form_row(form.pageType) }}
-                {% if form.status is defined %}
-                    {{ form_row(form.status) }}
-                {% endif %}
+
+<div class="row">
+    <div class="col-lg-8">
+        <div class="accordion mb-3" id="acb-page-general">
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#acb-page-general-body">
+                        {{ 'page.form.general'|trans({}, 'AdvancedContentBundle') }}
+                    </button>
+                </h2>
+                <div id="acb-page-general-body" class="accordion-collapse collapse show">
+                    <div class="accordion-body">
+                        {{ form_row(form.pageIdentifier) }}
+                        {{ form_row(form.pageType) }}
+                        {% if form.status is defined %}
+                            {{ form_row(form.status) }}
+                        {% endif %}
+                    </div>
+                </div>
             </div>
         </div>
+
         {% if form.pageMeta is defined %}
-            <div class="ui hidden divider"></div>
-            <div class="ui fluid styled accordion">
-                <div class="active title">
-                    <i class="dropdown icon"></i>
-                    {{ 'page.form.page_meta'|trans({}, 'AdvancedContentBundle') }}
-                </div>
-                <div class="active content">
-                    {{ form_widget(form.pageMeta) }}
+            <div class="accordion mb-3" id="acb-page-meta">
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#acb-page-meta-body">
+                            {{ 'page.form.page_meta'|trans({}, 'AdvancedContentBundle') }}
+                        </button>
+                    </h2>
+                    <div id="acb-page-meta-body" class="accordion-collapse collapse show">
+                        <div class="accordion-body">
+                            {{ form_widget(form.pageMeta) }}
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
+
         {% if form.content is defined %}
-            <div class="ui hidden divider"></div>
-            <div class="ui fluid styled accordion">
-                <div class="active title">
-                    <i class="dropdown icon"></i>
-                    {{ 'page.form.content'|trans({}, 'AdvancedContentBundle') }}
-                </div>
-                <div class="active content">
-                    {{ form_widget(form.content) }}
+            <div class="accordion mb-3" id="acb-page-content">
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#acb-page-content-body">
+                            {{ 'page.form.content'|trans({}, 'AdvancedContentBundle') }}
+                        </button>
+                    </h2>
+                    <div id="acb-page-content-body" class="accordion-collapse collapse show">
+                        <div class="accordion-body">
+                            {{ form_widget(form.content) }}
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
+
         {% if page.id %}
-            <div class="ui hidden divider"></div>
-            <div class="ui fluid styled accordion">
-                <div class="active title">
-                    <i class="dropdown icon"></i>
-                    {{ 'sherlockode_sylius_acb.form.history'|trans }}
-                </div>
-                <div class="active content">
-                    {{ include('@SherlockodeAdvancedContent/Version/page_list.html.twig', {'page': page}) }}
+            <div class="accordion mb-3" id="acb-page-history">
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#acb-page-history-body">
+                            {{ 'sherlockode_sylius_acb.form.history'|trans }}
+                        </button>
+                    </h2>
+                    <div id="acb-page-history-body" class="accordion-collapse collapse">
+                        <div class="accordion-body">
+                            {{ include('@SherlockodeAdvancedContent/Version/page_list.html.twig', {'page': page}) }}
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </div>
-    <div class="four wide column">
+
+    <div class="col-lg-4">
         {% if form.scopes is defined %}
-            <div class="ui fluid styled accordion">
-                <div class="active title">
-                    <i class="dropdown icon"></i>
-                    {{ 'sherlockode_sylius_acb.form.scope'|trans }}
-                </div>
-                <div class="active content">
-                    <div class="field">
-                        {{ form_widget(form.scopes) }}
-                    </div>
-                    <div class="ui checkbox">
-                        <input type="checkbox" id="acb-scopes-select-all">
-                        <label for="acb-scopes-select-all">{{ 'content.form.scopes_select_all'|trans({}, 'AdvancedContentBundle') }}</label>
+            <div class="card mb-3">
+                <div class="card-header">{{ 'sherlockode_sylius_acb.form.scope'|trans }}</div>
+                <div class="card-body">
+                    {{ form_widget(form.scopes) }}
+                    <div class="form-check mt-2">
+                        <input class="form-check-input" type="checkbox" id="acb-scopes-select-all">
+                        <label class="form-check-label" for="acb-scopes-select-all">
+                            {{ 'content.form.scopes_select_all'|trans({}, 'AdvancedContentBundle') }}
+                        </label>
                     </div>
                 </div>
             </div>
         {% endif %}
+
         {{ include('@SherlockodeSyliusAdvancedContentPlugin/admin/Page/_preview.html.twig') }}
-        <div class="ui segment center aligned">
-            <div class="ui buttons">
-                <button class="ui labeled icon primary button" type="submit">
+
+        <div class="card">
+            <div class="card-body text-center">
+                <button class="btn btn-primary" type="submit">
                     {% if page.id %}
-                        <i class="save icon"></i> {{ 'sylius.ui.save_changes'|trans }}
+                        <i class="fas fa-save"></i> {{ 'sylius.ui.save_changes'|trans }}
                     {% else %}
-                        <i class="plus icon"></i> {{ 'sylius.ui.create'|trans }}
+                        <i class="fas fa-plus"></i> {{ 'sylius.ui.create'|trans }}
                     {% endif %}
                 </button>
             </div>
         </div>
     </div>
 </div>
+
+{{ include('@SherlockodeSyliusAdvancedContentPlugin/admin/_confirmation_modal.html.twig') }}

--- a/src/Resources/views/admin/Page/_preview.html.twig
+++ b/src/Resources/views/admin/Page/_preview.html.twig
@@ -6,25 +6,21 @@
         {% endif %}
     {% endfor %}
 
-    <div class="ui hidden divider"></div>
-    <div class="ui fluid styled accordion">
-        <div class="active title">
-            <i class="dropdown icon"></i>
-            {{ 'sherlockode_sylius_acb.form.preview'|trans }}
-        </div>
-        <div class="active content">
+    <div class="card mb-3">
+        <div class="card-header">{{ 'sherlockode_sylius_acb.form.preview'|trans }}</div>
+        <div class="card-body">
             {% for code, name in channels %}
                 {% if channels|length > 1 %}
-                <h5>{{ name }}</h5>
+                    <h6 class="mb-2">{{ name }}</h6>
                 {% endif %}
                 {% for scope in page.scopes %}
                     {% if scope.channel.code == code %}
-                        <a target="_blank" class="ui icon default button" href="{{ path('sherlockode_sylius_acb_admin_page_preview', {'_channel_code': scope.channel.code, '_locale': scope.locale.code, 'pageIdentifier': page.pageIdentifier}) }}">
+                        <a target="_blank"
+                           class="btn btn-outline-secondary btn-sm mb-2"
+                           href="{{ path('sherlockode_sylius_acb_admin_page_preview', {'_channel_code': scope.channel.code, '_locale': scope.locale.code, 'pageIdentifier': page.pageIdentifier}) }}">
                             <i class="fa-solid fa-eye"></i>
                             {{ 'sherlockode_sylius_acb.form.show_preview'|trans }} ({{ scope.locale.code }})
-                        </a>
-                        <br>
-                        <br>
+                        </a><br>
                     {% endif %}
                 {% endfor %}
             {% endfor %}

--- a/src/Resources/views/admin/_confirmation_modal.html.twig
+++ b/src/Resources/views/admin/_confirmation_modal.html.twig
@@ -1,0 +1,15 @@
+<div class="modal fade" id="confirmation-modal" tabindex="-1" aria-labelledby="confirmation-modal-title" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="confirmation-modal-title">{{ 'sylius.ui.are_your_sure_you_want_to_perform_this_action'|trans }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'sylius.ui.close'|trans }}"></button>
+            </div>
+            <div class="modal-body"></div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'sylius.ui.cancel'|trans }}</button>
+                <button type="button" class="btn btn-danger" id="confirmation-button">{{ 'sylius.ui.delete'|trans }}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Resources/views/admin/stylesheets.html.twig
+++ b/src/Resources/views/admin/stylesheets.html.twig
@@ -1,2 +1,0 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/css/bootstrap-grid.min.css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css"/>

--- a/src/Resources/views/tools.html.twig
+++ b/src/Resources/views/tools.html.twig
@@ -1,66 +1,67 @@
 {% extends '@SyliusAdmin/layout.html.twig' %}
 {% trans_default_domain 'AdvancedContentBundle' %}
 
-{% form_theme importForm '@SyliusAdmin/Form/theme.html.twig' %}
-{% form_theme exportForm '@SyliusAdmin/Form/theme.html.twig' %}
+{% form_theme importForm '@SyliusAdmin/shared/form_theme.html.twig' %}
+{% form_theme exportForm '@SyliusAdmin/shared/form_theme.html.twig' %}
 
-{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 {% import "@SherlockodeAdvancedContent/Common/Macros/tabs.html.twig" as tabUtils %}
 
 {% block title %}{{ 'tools.label'|trans }} {{ parent() }}{% endblock %}
 
 {% set tabs = [] %}
 {% set importExportContent %}
-    <div class="ui segment">
-        <h3 class="ui dividing header">{{ 'tools.import.title'|trans }}</h3>
-        <p>{{ 'tools.import.description'|trans }}</p>
-        <div class="acb-tools-import">
-            {{ form_start(importForm, {'attr': {'class': 'ui loadable form'}}) }}
-            {{ form_errors(importForm) }}
-            {{ form_row(importForm.file) }}
-            <div class="ui hidden divider"></div>
-            <div class="ui buttons" style="display: inline;">
-                <button class="ui primary button" type="submit">{{ 'tools.import.btn'|trans }}</button>
+    <div class="card mb-3">
+        <div class="card-body">
+            <h3 class="mb-3 pb-2 border-bottom">{{ 'tools.import.title'|trans }}</h3>
+            <p>{{ 'tools.import.description'|trans }}</p>
+            <div class="acb-tools-import">
+                {{ form_start(importForm) }}
+                {{ form_errors(importForm) }}
+                {{ form_row(importForm.file) }}
+                <div class="mt-3">
+                    <button class="btn btn-primary" type="submit">{{ 'tools.import.btn'|trans }}</button>
+                </div>
+                {{ form_end(importForm) }}
             </div>
-            {{ form_end(importForm) }}
         </div>
     </div>
-    <div class="ui segment">
-        <h3 class="ui dividing header">{{ 'tools.export.title'|trans }}</h3>
-        <p>{{ 'tools.export.description'|trans }}</p>
-        <div class="acb-tools-export">
-            {{ form_start(exportForm, {'attr': {'class': 'ui loadable form'}}) }}
-            {{ form_errors(exportForm) }}
-            <div class="ui two column stackable grid">
-                <div class="eight wide column">
-                    <div class="acb-export-entities">
-                        {{ form_row(exportForm.page) }}
-                        {% if exportForm.page.vars.choices is not empty %}
-                            {{ form_row(exportForm.pageAll) }}
-                        {% else %}
-                            {{ 'tools.export.empty_list.page'|trans }}
-                        {% endif %}
+    <div class="card mb-3">
+        <div class="card-body">
+            <h3 class="mb-3 pb-2 border-bottom">{{ 'tools.export.title'|trans }}</h3>
+            <p>{{ 'tools.export.description'|trans }}</p>
+            <div class="acb-tools-export">
+                {{ form_start(exportForm) }}
+                {{ form_errors(exportForm) }}
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="acb-export-entities">
+                            {{ form_row(exportForm.page) }}
+                            {% if exportForm.page.vars.choices is not empty %}
+                                {{ form_row(exportForm.pageAll) }}
+                            {% else %}
+                                {{ 'tools.export.empty_list.page'|trans }}
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="acb-export-entities">
+                            {{ form_row(exportForm.content) }}
+                            {% if exportForm.content.vars.choices is not empty %}
+                                {{ form_row(exportForm.contentAll) }}
+                            {% else %}
+                                {{ 'tools.export.empty_list.content'|trans }}
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
-                <div class="eight wide column">
-                    <div class="acb-export-entities">
-                        {{ form_row(exportForm.content) }}
-                        {% if exportForm.content.vars.choices is not empty %}
-                            {{ form_row(exportForm.contentAll) }}
-                        {% else %}
-                            {{ 'tools.export.empty_list.content'|trans }}
-                        {% endif %}
-                    </div>
+                <div class="mt-3">
+                    <button class="btn btn-primary" type="submit">{{ 'tools.export.btn'|trans }}</button>
                 </div>
+                {% if exportForm._token is defined %}
+                    {{ form_widget(exportForm._token) }}
+                {% endif %}
+                {{ form_end(exportForm, {'render_rest': false}) }}
             </div>
-            <div class="ui hidden divider"></div>
-            <div class="ui buttons" style="display: inline;">
-                <button class="ui primary button" type="submit">{{ 'tools.export.btn'|trans }}</button>
-            </div>
-            {% if exportForm._token is defined %}
-                {{ form_widget(exportForm._token) }}
-            {% endif %}
-            {{ form_end(exportForm, {'render_rest': false}) }}
         </div>
     </div>
 {% endset %}
@@ -72,22 +73,22 @@
 }]) %}
 
 {% set configurationContent %}
-    <div class="ui segment">
-        <h3 class="ui dividing header">{{ 'page_type.label'|trans }}</h3>
-        <p>
-            {{ 'page_type.description'|trans }}
-        </p>
-        {{ include('@SherlockodeAdvancedContent/Tools/_pageTypes.html.twig', {'pageTypes': pageTypes, 'form': pageTypeForm}) }}
+    <div class="card mb-3">
+        <div class="card-body">
+            <h3 class="mb-3 pb-2 border-bottom">{{ 'page_type.label'|trans }}</h3>
+            <p>{{ 'page_type.description'|trans }}</p>
+            {{ include('@SherlockodeAdvancedContent/Tools/_pageTypes.html.twig', {'pageTypes': pageTypes, 'form': pageTypeForm}) }}
+        </div>
     </div>
     {% if acb_is_scopes_enabled() and not sylius_acb_is_scopes_up_to_date() %}
-        <div class="ui segment">
-            <h3 class="ui dividing header">{{ 'sherlockode_sylius_acb.scopes.segment_title'|trans({}, 'messages') }}</h3>
-            <p>
-                {{ 'sherlockode_sylius_acb.scopes.details'|trans({}, 'messages') }}
-            </p>
-            <a href="{{ path('sherlockode_sylius_acb_admin_scope_init') }}" class="ui primary button">
-                {{ 'sherlockode_sylius_acb.scopes.button'|trans({}, 'messages') }}
-            </a>
+        <div class="card mb-3">
+            <div class="card-body">
+                <h3 class="mb-3 pb-2 border-bottom">{{ 'sherlockode_sylius_acb.scopes.segment_title'|trans({}, 'messages') }}</h3>
+                <p>{{ 'sherlockode_sylius_acb.scopes.details'|trans({}, 'messages') }}</p>
+                <a href="{{ path('sherlockode_sylius_acb_admin_scope_init') }}" class="btn btn-primary">
+                    {{ 'sherlockode_sylius_acb.scopes.button'|trans({}, 'messages') }}
+                </a>
+            </div>
         </div>
     {% endif %}
 {% endset %}
@@ -98,7 +99,19 @@
     'content': configurationContent
 }]) %}
 
-{% block content %}
-    {{ headers.default('tools.label'|trans, 'cogs') }}
-    {{ tabUtils.buildTabs(tabs) }}
+{% block body %}
+    {{ include('@SyliusAdmin/shared/crud/common/sidebar.html.twig') }}
+    {{ include('@SyliusAdmin/shared/crud/common/navbar.html.twig') }}
+    <div class="page-wrapper">
+        <div class="page-header">
+            <div class="container-xl">
+                <h2 class="page-title"><i class="fa-solid fa-gears me-2"></i>{{ 'tools.label'|trans }}</h2>
+            </div>
+        </div>
+        <div class="page-body">
+            <div class="container-xl">
+                {{ tabUtils.buildTabs(tabs) }}
+            </div>
+        </div>
+    </div>
 {% endblock %}

--- a/src/Scope/ChannelLocaleScopeHandler.php
+++ b/src/Scope/ChannelLocaleScopeHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Scope;
 
 use App\Entity\Channel\Channel;

--- a/src/Scope/ScopeInitializer.php
+++ b/src/Scope/ScopeInitializer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Scope;
 
 use App\Entity\Channel\Channel;

--- a/src/Twig/Extension/ScopeExtension.php
+++ b/src/Twig/Extension/ScopeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\Twig\Extension;
 
 use Sherlockode\SyliusAdvancedContentPlugin\Scope\ScopeInitializer;

--- a/src/User/AdminUserProvider.php
+++ b/src/User/AdminUserProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sherlockode\SyliusAdvancedContentPlugin\User;
 
 use Sherlockode\AdvancedContentBundle\User\AnonymousUserProvider;


### PR DESCRIPTION
## Context

The plugin did not boot on Sylius 2. The resource component namespaces moved, the resource and routing configuration formats changed, and the admin UI switched from Semantic UI to Bootstrap 5 / Tabler — so every template shipped by the plugin rendered unstyled or broken.

This PR ports the whole plugin to Sylius 2 / Symfony 7.4 / PHP 8.2.

| | Before | After |
|---|---|---|
| `php` | `^7.4 \|\| ^8.1` | `^8.2` |
| `sylius/sylius` | `^1.10` | `^2.0` |
| `symfony/*` | (implicit) | `^7.4` |

## Foundation

- `declare(strict_types=1)` across all of `src/`
- Resource namespace migration: `Sylius\Component\Resource\*` → `Sylius\Resource\*` (`Model\ResourceInterface`, `Factory\FactoryInterface`, `Doctrine\Persistence\RepositoryInterface`), FQCNs resolved against `sylius/resource` 2.2

## Configuration

- `sylius_resource.yaml`: dropped `form` from `classes` (removed in Sylius 2), and registered `ContentRepository` on the `content` resource — the admin contents grid needs `createListQueryBuilder()`, which was missing and produced `createListQueryBuilder undefined` on `/admin/acb/contents/`
- `admin_routing.yaml`: `@SyliusAdmin/shared/crud` templates, `form` moved to the route level. The two custom controllers keep being referenced by their service id (`sherlockode_sylius_acb.controller.scope` and `.preview`); both services are declared `public: true`, so `ContainerControllerResolver` resolves them as-is and no FQCN alias is needed
- `ScopeInitCommand` is declared in a dedicated `commands.xml`, imported by `config.yaml`

## PHP modernisation

- `PreviewController`, `ScopeController`, `AdminVersionListener`, `AdminGridListener`: constructor property promotion, native types, redundant phpdoc removed
- `ScopeInitCommand`: `execute(): int`. The command name and description stay in `configure()` rather than in an attribute — a plugin cannot presume that the host application autoconfigures its services, and the service is already tagged `console.command`

## Admin templates (Semantic UI → Bootstrap 5 / Tabler)

- `Page/_form`, `Content/_form`, `Page/_preview`: BS5 grids, cards and accordions; form context resolved through `hookable_metadata`
- Tabs macro: `nav-tabs` driven by the BS5 data API — the jQuery `.tab()` call is gone, no JS needed
- `classes` / `collapse` macros: Semantic UI utility classes → BS5 / Tabler
- `tools.html.twig`: BS5 cards, `body` block and the Sylius 2 admin layout
- Form themes: `@SyliusUi/Form/theme` → `@SyliusAdmin/shared/form_theme`
- Status badges use Tabler variants (`bg-*-lt`)
- `acb-notification.js`: native BS5 modal replacing Semantic UI + the jQuery global (both absent from Sylius 2), with a new `admin/_confirmation_modal.html.twig` template and a `window.confirm()` fallback when the markup is not rendered
- `admin/stylesheets.html.twig` removed: it only pulled the jQuery UI CSS from an external CDN, and the `sylius_ui` block that injected it on the four admin screens no longer exists in Sylius 2. Nothing referenced the template any more. The `jquery-ui` sortable JS the builder relies on stays bundled by the application

## Bug fixes surfaced along the way

**Doctrine ORM 3 `TypeError` on scoped modals.** `getByScopeQueryBuilder()` passed a bare PHP array to `QueryBuilder::setParameters()`, which ORM 3 rejects (it requires an `ArrayCollection`). The exception was thrown before any Twig rendering, so every scoped ACB modal (`acb_content_modal`) returned a guaranteed HTTP 500 as soon as the scope was resolved — and `scopes.enabled` is hardcoded to `true` by `SherlockodeSyliusAdvancedContentExtension`, making it systematic in production. Replaced with two successive `setParameter()` calls, a form valid under both ORM 2 and 3. `PageRepository` carried the same latent defect (not reachable today, since regular ACB page scopes are always `null`) and was fixed in the same pass.

**Inert Gedmo traits on `Page`.** Since the annotations → XML conversion in v0.4.0, the `TimestampableEntity` / `BlameableEntity` traits had no effect: the XML driver does not inspect PHP attributes on traits. `Page.orm.xml` imported the `gedmo` namespace without ever using it, so `created_at` / `updated_at` / `created_by` / `updated_by` were unmapped — `doctrine:migrations:diff` wanted to DROP them and timestampable stopped being maintained. The four fields are now declared explicitly with `<gedmo:timestampable>` / `<gedmo:blameable>` tags, the way Sylius core does for its XML-mapped entities. Types match the existing schema (`created_at` / `updated_at` datetime NOT NULL, `created_by` / `updated_by` string(255) nullable).

## Breaking change

This branch targets Sylius 2 exclusively — it drops support for Sylius 1.x, PHP 7.4 and PHP 8.1. It warrants a new major (or `2.x`) release line rather than a patch on the current one.

## Verification

The two bug fixes above were found and fixed during manual QA on a Sylius 2 application, which is also how the routing, resource and controller wiring was exercised (contents and pages grids, page and content forms, preview, tools page, scoped content modals).

The command registration and controller wiring were re-checked on that application after the review round: `bin/console list` still exposes `sherlockode:sylius-acb:init-scope` without the attribute, the command runs, `router:match /admin/acb/scope/init` resolves `sherlockode_sylius_acb.controller.scope::updateScopesAction()`, and `lint:container` passes.

No automated test suite covers these paths in the plugin, so reviewers should keep in mind:

- the ported templates have no regression coverage — visual checks only
- the quickest confirmation for the `Page` mapping is running `doctrine:migrations:diff` on a Sylius 2 application and checking the diff comes out empty
